### PR TITLE
All: Fix invalid module error handling in API

### DIFF
--- a/Misc/module-template/projects/examplemodule/src/lib/services/api.service.ts
+++ b/Misc/module-template/projects/examplemodule/src/lib/services/api.service.ts
@@ -36,8 +36,11 @@ export class ApiService {
         this.http.post('/api/module/request', payload).subscribe((r: any) => {
             if (r === undefined || r === null) {
                 resp = this.emptyResponse;
+            } else if (r.error) {
+                resp = r;
+            } else {
+                resp = r.payload;
             }
-            resp = r.payload;
         }, (err) => {
             resp = err.error;
             if (err.status === 401) {

--- a/cabinet/projects/cabinet/src/lib/services/api.service.ts
+++ b/cabinet/projects/cabinet/src/lib/services/api.service.ts
@@ -36,8 +36,11 @@ export class ApiService {
         this.http.post('/api/module/request', payload).subscribe((r: any) => {
             if (r === undefined || r === null) {
                 resp = this.emptyResponse;
+            } else if (r.error) {
+                resp = r;
+            } else {
+                resp = r.payload;
             }
-            resp = r.payload;
         }, (err) => {
             resp = err.error;
             if (err.status === 401) {

--- a/cabinet/projects/cabinet/src/module.json
+++ b/cabinet/projects/cabinet/src/module.json
@@ -3,6 +3,6 @@
     "title": "Cabinet",
     "author": "newbi3",
     "description": "A simple browser based file manager for the WiFi Pineapple.",
-    "version": "1.1",
+    "version": "1.2",
     "firmware_required": "1.0.0"
 }

--- a/evilportal/projects/evilportal/src/lib/services/api.service.ts
+++ b/evilportal/projects/evilportal/src/lib/services/api.service.ts
@@ -36,8 +36,11 @@ export class ApiService {
         this.http.post('/api/module/request', payload).subscribe((r: any) => {
             if (r === undefined || r === null) {
                 resp = this.emptyResponse;
+            } else if (r.error) {
+                resp = r;
+            } else {
+                resp = r.payload;
             }
-            resp = r.payload;
         }, (err) => {
             resp = err.error;
             if (err.status === 401) {

--- a/evilportal/projects/evilportal/src/module.json
+++ b/evilportal/projects/evilportal/src/module.json
@@ -3,6 +3,6 @@
     "title": "Evil Portal",
     "description": "An evil captive portal for the WiFi Pineapple.",
     "author": "newbi3",
-    "version": "1.3",
+    "version": "1.4",
     "firmware_required": "1.0.0"
 }

--- a/httpeek/projects/httpeek/src/lib/services/api.service.ts
+++ b/httpeek/projects/httpeek/src/lib/services/api.service.ts
@@ -36,8 +36,11 @@ export class ApiService {
         this.http.post('/api/module/request', payload).subscribe((r: any) => {
             if (r === undefined || r === null) {
                 resp = this.emptyResponse;
+            } else if (r.error) {
+                resp = r;
+            } else {
+                resp = r.payload;
             }
-            resp = r.payload;
         }, (err) => {
             resp = err.error;
             if (err.status === 401) {

--- a/httpeek/projects/httpeek/src/module.json
+++ b/httpeek/projects/httpeek/src/module.json
@@ -2,7 +2,7 @@
     "name": "httpeek",
     "title": "HTTPeek",
     "description": "View plaintext HTTP traffic, such as cookies and images.",
-    "version": "1.1",
     "author": "newbi3",
+    "version": "1.2",
     "firmware_required": "1.0.0"
 }

--- a/mdk4/projects/mdk4/src/lib/services/api.service.ts
+++ b/mdk4/projects/mdk4/src/lib/services/api.service.ts
@@ -36,8 +36,11 @@ export class ApiService {
         this.http.post('/api/module/request', payload).subscribe((r: any) => {
             if (r === undefined || r === null) {
                 resp = this.emptyResponse;
+            } else if (r.error) {
+                resp = r;
+            } else {
+                resp = r.payload;
             }
-            resp = r.payload;
         }, (err) => {
             resp = err.error;
             if (err.status === 401) {

--- a/mdk4/projects/mdk4/src/module.json
+++ b/mdk4/projects/mdk4/src/module.json
@@ -2,7 +2,7 @@
     "name": "mdk4",
     "title": "MDK4",
     "description": "Web GUI for the MDK4 wireless testing tool.",
-    "version": "1.2",
     "author": "newbi3",
+    "version": "1.3",
     "firmware_required": "1.0.0"
 }

--- a/nmap/projects/nmap/src/lib/services/api.service.ts
+++ b/nmap/projects/nmap/src/lib/services/api.service.ts
@@ -36,8 +36,11 @@ export class ApiService {
         this.http.post('/api/module/request', payload).subscribe((r: any) => {
             if (r === undefined || r === null) {
                 resp = this.emptyResponse;
+            } else if (r.error) {
+                resp = r;
+            } else {
+                resp = r.payload;
             }
-            resp = r.payload;
         }, (err) => {
             resp = err.error;
             if (err.status === 401) {

--- a/nmap/projects/nmap/src/module.json
+++ b/nmap/projects/nmap/src/module.json
@@ -2,7 +2,7 @@
     "name": "nmap",
     "title": "Nmap",
     "description": "Web GUI for Nmap, the popular network mapping tool.",
-    "version": "1.2",
     "author": "newbi3",
+    "version": "1.3",
     "firmware_required": "1.0.0"
 }

--- a/tcpdump/projects/tcpdump/src/lib/services/api.service.ts
+++ b/tcpdump/projects/tcpdump/src/lib/services/api.service.ts
@@ -36,8 +36,11 @@ export class ApiService {
         this.http.post('/api/module/request', payload).subscribe((r: any) => {
             if (r === undefined || r === null) {
                 resp = this.emptyResponse;
+            } else if (r.error) {
+                resp = r;
+            } else {
+                resp = r.payload;
             }
-            resp = r.payload;
         }, (err) => {
             resp = err.error;
             if (err.status === 401) {

--- a/tcpdump/projects/tcpdump/src/module.json
+++ b/tcpdump/projects/tcpdump/src/module.json
@@ -2,7 +2,7 @@
     "name": "tcpdump",
     "title": "TCPDump",
     "description": "Web GUI for the tcpdump packet analyzer tool.",
-    "version": "1.2",
     "author": "newbi3",
+    "version": "1.3",
     "firmware_required": "1.0.0"
 }


### PR DESCRIPTION
This PR fixes an issue across all modules where, if an error was returned from the modules Python back end, would go ignored.

